### PR TITLE
ci: add build verification workflow for PRs

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,57 @@
+name: Build on PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build-astro:
+    name: Build Astro
+    runs-on: ubuntu-latest
+    if: hashFiles('astro.config.mjs') != ''
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          ASTRO_BASE: "/"
+
+  build-hugo:
+    name: Build Hugo
+    runs-on: ubuntu-latest
+    if: hashFiles('hugo.toml') != ''
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: "0.152.0"
+          extended: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Ajoute le workflow build-pr.yml qui teste le build à chaque création/mise à jour de PR.

Ce workflow doit être sur la branche main pour que GitHub le déclenche (les workflows pull_request sont lus depuis la branche de base).