### PR TITLE
fix: create accessibility page and fix broken footer link

### DIFF
--- a/config/_default/menus.fr.toml
+++ b/config/_default/menus.fr.toml
@@ -39,5 +39,5 @@ weight = 1
 
 [[footer]]
 name = "Accessibilité"
-url = "/#accessibilite"
+url = "/accessibilite/"
 weight = 2

--- a/content/english/accessibilite.md
+++ b/content/english/accessibilite.md
@@ -1,0 +1,42 @@
+---
+title: "Accessibilité"
+meta_title: "Accessibilité - CTO de Lyon"
+description: "Engagements d'accessibilité du site de la communauté CTO de Lyon"
+draft: false
+---
+
+La Communauté CTO de Lyon s'engage à rendre son site accessible au plus grand nombre, conformément aux standards du web et aux bonnes pratiques en matière d'accessibilité numérique.
+
+## Objectif de conformité
+
+Nous visons une conformité au référentiel **WCAG 2.1 niveau AA** (Web Content Accessibility Guidelines). Ce référentiel international définit les critères permettant de rendre les contenus web accessibles aux personnes en situation de handicap.
+
+## Fonctionnalités d'accessibilité intégrées
+
+### Panneau d'accessibilité
+
+Le site dispose d'un panneau d'accessibilité intégré permettant de personnaliser l'affichage selon vos besoins :
+
+- **Taille de police ajustable** : augmentez ou réduisez la taille du texte pour un meilleur confort de lecture.
+- **Police adaptée à la dyslexie** : activez une police spécialement conçue pour faciliter la lecture aux personnes dyslexiques.
+- **Contraste élevé** : renforcez le contraste entre le texte et l'arrière-plan pour une meilleure lisibilité.
+- **Espacement du texte** : augmentez l'espacement entre les lignes et les paragraphes.
+- **Lettrage élargi** : augmentez l'espacement entre les caractères pour faciliter la lecture.
+
+### Mode sombre
+
+Le site propose un mode sombre natif qui s'adapte automatiquement aux préférences de votre système d'exploitation. Vous pouvez également basculer manuellement entre le mode clair et le mode sombre.
+
+### Navigation au clavier
+
+L'ensemble du site est navigable au clavier. Vous pouvez utiliser la touche `Tab` pour passer d'un élément interactif à l'autre et la touche `Entrée` pour activer les liens et boutons.
+
+### Attributs ARIA et labels
+
+Les éléments interactifs du site sont accompagnés d'attributs ARIA (Accessible Rich Internet Applications) et de labels explicites pour garantir une bonne restitution par les technologies d'assistance, notamment les lecteurs d'écran.
+
+## Signaler un problème
+
+Si vous rencontrez un problème d'accessibilité sur ce site ou si vous souhaitez nous faire part de vos suggestions d'amélioration, n'hésitez pas à nous contacter à l'adresse suivante : [contact@cto-de-lyon.fr](mailto:contact@cto-de-lyon.fr).
+
+Nous nous engageons à prendre en compte vos retours et à améliorer continuellement l'accessibilité de notre site.


### PR DESCRIPTION
## Summary
- Create `/accessibilite/` page describing site accessibility features
- Fix footer menu link from broken `/#accessibilite` to `/accessibilite/`

## Changes
- `content/english/accessibilite.md` — new page
- `config/_default/menus.fr.toml` — updated footer URL

## Test plan
- [ ] Build Hugo réussi
- [ ] Footer link navigates to accessibility page
- [ ] Page content in French, well-structured
- [ ] Mobile responsive

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)