### PR TITLE
ci: fix build-pr.yml — remove dead Astro job and invalid hashFiles

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -5,32 +5,9 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  build-astro:
-    name: Build Astro
-    runs-on: ubuntu-latest
-    if: hashFiles('astro.config.mjs') != ''
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-        env:
-          ASTRO_BASE: "/"
-
-  build-hugo:
+  build:
     name: Build Hugo
     runs-on: ubuntu-latest
-    if: hashFiles('hugo.toml') != ''
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Remove the `build-astro` job (dead code since Hugo migration PR #5)
- Remove the unsupported `hashFiles()` job-level `if` condition from `build-hugo`
- Simplify to a single `build` job aligned with `deploy.yml`

Fixes the GitHub Actions error:
```
Unrecognized function: 'hashFiles'. Located at position 1 within expression: hashFiles('astro.config.mjs') != ''
Unrecognized function: 'hashFiles'. Located at position 1 within expression: hashFiles('hugo.toml') != ''
```

## Test plan

- [ ] Workflow YAML is valid (no more `hashFiles` errors)
- [ ] PR builds trigger correctly on open/synchronize/reopen
- [ ] Hugo build passes in CI

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)