### PR TITLE
fix: resolve SRI hash mismatch and Swiper not defined errors

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,4 @@
+// main script
+(function () {
+  "use strict";
+})();

--- a/layouts/_partials/essentials/script.html
+++ b/layouts/_partials/essentials/script.html
@@ -23,15 +23,8 @@
 {{ $scripts = $scripts | append (resources.Get "js/main.js") }}
 {{ $scripts = $scripts | resources.Concat "js/script.js" }}
 
-{{ if $scriptsLazy }}
-  {{ $scriptsLazy = $scriptsLazy | resources.Concat "js/script-lazy.js" }}
-{{ else }}
-  {{ $scriptsLazy = resources.FromString "js/script-lazy.js" "// empty" }}
-{{ end }}
-
 {{ if hugo.IsProduction }}
   {{ $scripts = $scripts | minify | fingerprint }}
-  {{ $scriptsLazy = $scriptsLazy | minify | fingerprint }}
 {{ end }}
 
 {{/* scripts */}}
@@ -40,13 +33,19 @@
   integrity="{{ $scripts.Data.Integrity }}"
   src="{{ $scripts.RelPermalink }}"></script>
 
-{{/* scripts lazy */}}
-<script
-  defer
-  async
-  crossorigin="anonymous"
-  integrity="{{ $scriptsLazy.Data.Integrity }}"
-  src="{{ $scriptsLazy.RelPermalink }}"></script>
+{{/* scripts lazy — only output if lazy plugins are declared */}}
+{{ if $scriptsLazy }}
+  {{ $scriptsLazy = $scriptsLazy | resources.Concat "js/script-lazy.js" }}
+  {{ if hugo.IsProduction }}
+    {{ $scriptsLazy = $scriptsLazy | minify | fingerprint }}
+  {{ end }}
+  <script
+    defer
+    async
+    crossorigin="anonymous"
+    integrity="{{ $scriptsLazy.Data.Integrity }}"
+    src="{{ $scriptsLazy.RelPermalink }}"></script>
+{{ end }}
 
 {{/* Stubs - modules non utilisés */}}
 {{ partialCached "pwa.html" . }}

--- a/layouts/_partials/essentials/style.html
+++ b/layouts/_partials/essentials/style.html
@@ -60,17 +60,9 @@
 {{ $styles = $styles | append $tailwindCSS }}
 {{ $styles = $styles | resources.Concat "css/style.css" }}
 
-{{ if $stylesLazy }}
-  {{ $stylesLazy = $stylesLazy | resources.Concat "css/style-lazy.css" }}
-{{ else }}
-  {{ $stylesLazy = resources.FromString "css/style-lazy.css" "/* empty */" }}
-{{ end }}
-
 {{ if hugo.IsProduction }}
   {{ $styles = $styles | fingerprint }}
-  {{ $stylesLazy = $stylesLazy | minify | fingerprint }}
 {{ end }}
-
 
 <!-- link main style -->
 <link
@@ -78,10 +70,16 @@
   integrity="{{ $styles.Data.Integrity }}"
   rel="stylesheet" />
 
-<!-- link lazy style -->
-<link
-  rel="stylesheet"
-  href="{{ $stylesLazy.RelPermalink }}"
-  integrity="{{ $stylesLazy.Data.Integrity }}"
-  media="print"
-  onload="this.media='all'; this.onload=null;" />
+<!-- link lazy style — only output if lazy plugins are declared -->
+{{ if $stylesLazy }}
+  {{ $stylesLazy = $stylesLazy | resources.Concat "css/style-lazy.css" }}
+  {{ if hugo.IsProduction }}
+    {{ $stylesLazy = $stylesLazy | minify | fingerprint }}
+  {{ end }}
+  <link
+    rel="stylesheet"
+    href="{{ $stylesLazy.RelPermalink }}"
+    integrity="{{ $stylesLazy.Data.Integrity }}"
+    media="print"
+    onload="this.media='all'; this.onload=null;" />
+{{ end }}


### PR DESCRIPTION
## Summary

Fixes two production errors after merging PRs #26-#29:

- **SRI integrity hash mismatch**: `script.html` and `style.html` created empty lazy files (`"// empty"` / `"/* empty */"`) that, once minified, produced a SHA-256 of empty string. GitHub Pages served content that didn't match this hash → resources blocked by the browser. **Fix**: only emit lazy `<script>` / `<link>` tags when lazy plugins are actually declared in `hugo.toml`.

- **`Swiper is not defined`**: The theme's `assets/js/main.js` unconditionally initializes `new Swiper(...)`, but the Swiper library was removed in PR #26. The site doesn't use the testimonials slider. **Fix**: override `assets/js/main.js` at project level with an empty IIFE.

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] No `style-lazy` or `script-lazy` files in `public/`
- [ ] No Swiper reference in generated output
- [ ] No console errors in browser
- [ ] Logo CTO de Lyon still visible in hero section

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)