### PR TITLE
perf: remove unused preconnect and dns-prefetch hints

### DIFF
--- a/layouts/_partials/essentials/style.html
+++ b/layouts/_partials/essentials/style.html
@@ -1,18 +1,8 @@
 <!-- DNS preconnect -->
 <meta http-equiv="x-dns-prefetch-control" content="on" />
-<link rel="preconnect" href="https://use.fontawesome.com" crossorigin />
 <link rel="preconnect" href="//cdnjs.cloudflare.com" />
-<link rel="preconnect" href="//www.googletagmanager.com" />
-<link rel="preconnect" href="//www.google-analytics.com" />
-<link rel="dns-prefetch" href="https://use.fontawesome.com" />
-<link rel="dns-prefetch" href="//ajax.googleapis.com" />
 <link rel="dns-prefetch" href="//cdnjs.cloudflare.com" />
-<link rel="dns-prefetch" href="//www.googletagmanager.com" />
-<link rel="dns-prefetch" href="//www.google-analytics.com" />
 <link rel="dns-prefetch" href="//fonts.googleapis.com" />
-<link rel="dns-prefetch" href="//connect.facebook.net" />
-<link rel="dns-prefetch" href="//platform.linkedin.com" />
-<link rel="dns-prefetch" href="//platform.twitter.com" />
 
 <!-- google fonts -->
 {{ $pf:= site.Data.theme.fonts.font_family.primary }}


### PR DESCRIPTION
## Summary
- Remove preconnect and dns-prefetch hints for services not used on the site: Font Awesome direct CDN (`use.fontawesome.com`), Google Tag Manager, Google Analytics, Ajax googleapis, Facebook, LinkedIn SDK, and Twitter SDK
- Keep only hints for actively used services: `cdnjs.cloudflare.com` (Font Awesome CDN via hugo.toml), `fonts.googleapis.com` and `fonts.gstatic.com` (Google Fonts)
- Reduces unnecessary DNS lookups and connection overhead on page load

Closes #14

## Test plan
- [x] `npm run build` passes successfully
- [ ] Verify in browser DevTools (Network tab) that no connections are made to removed domains
- [ ] Verify Google Fonts and Font Awesome CDN still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)