### PR TITLE
feat: add Schema.org JSON-LD structured data for SEO

### DIFF
--- a/layouts/_partials/schema-org.html
+++ b/layouts/_partials/schema-org.html
@@ -1,0 +1,85 @@
+{{- /* Schema.org JSON-LD structured data for SEO */ -}}
+
+{{- $baseURL := site.BaseURL | strings.TrimRight "/" -}}
+{{- $data := index site.Data "cto-de-lyon" -}}
+
+{{- /* 1. Organization — all pages */ -}}
+{{- $description := "" -}}
+{{- with $data.introduction -}}
+  {{- $description = index .content 0 -}}
+{{- end -}}
+{{- $org := dict
+  "@context" "https://schema.org"
+  "@type" "Organization"
+  "name" "CTO de Lyon"
+  "url" $baseURL
+  "logo" (printf "%s/images/favicon.svg" $baseURL)
+  "description" $description
+  "contactPoint" (dict
+    "@type" "ContactPoint"
+    "email" "contact@cto-de-lyon.fr"
+    "contactType" "customer service"
+  )
+  "sameAs" (slice
+    "https://www.linkedin.com/groups/12921552/"
+    "https://github.com/cto-de-lyon"
+  )
+-}}
+<script type="application/ld+json">
+  {{- $org | jsonify | safeJS -}}
+</script>
+
+{{- /* 2. WebSite — all pages */ -}}
+{{- $website := dict
+  "@context" "https://schema.org"
+  "@type" "WebSite"
+  "name" site.Title
+  "url" $baseURL
+  "inLanguage" "fr-FR"
+  "publisher" (dict
+    "@type" "Organization"
+    "name" "CTO de Lyon"
+    "url" $baseURL
+  )
+-}}
+<script type="application/ld+json">
+  {{- $website | jsonify | safeJS -}}
+</script>
+
+{{- /* 3. Event — homepage only, one block per Luma event */ -}}
+{{- if .IsHome -}}
+  {{- $lumaEvents := index site.Data "luma-events" -}}
+  {{- if and $lumaEvents $lumaEvents.events -}}
+    {{- range $lumaEvents.events -}}
+      {{- $event := dict
+        "@context" "https://schema.org"
+        "@type" "Event"
+        "name" .name
+        "startDate" .startAt
+        "eventAttendanceMode" "https://schema.org/OfflineEventAttendanceMode"
+        "eventStatus" "https://schema.org/EventScheduled"
+        "location" (dict
+          "@type" "Place"
+          "name" .city
+          "address" (dict
+            "@type" "PostalAddress"
+            "addressLocality" .city
+            "addressCountry" "FR"
+          )
+        )
+        "url" .url
+        "organizer" (dict
+          "@type" "Organization"
+          "name" "CTO de Lyon"
+          "url" $baseURL
+        )
+      -}}
+      {{- with .coverUrl -}}
+        {{- $event = merge $event (dict "image" .) -}}
+      {{- end }}
+<script type="application/ld+json">
+  {{- $event | jsonify | safeJS -}}
+</script>
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -10,6 +10,7 @@
     {{ partial "essentials/head.html" . }}
     {{ partial "accessibility-head.html" . }}
     {{ partialCached "essentials/style.html" . }}
+    {{ partial "schema-org.html" . }}
   </head>
 
   <body>


### PR DESCRIPTION
## Summary

- Add `layouts/_partials/schema-org.html` partial that generates JSON-LD structured data using Hugo `dict`/`jsonify` with `safeJS` for proper rendering
- Include the partial in `layouts/baseof.html` `<head>` section
- **Organization** schema (all pages): name, URL, logo, description, contact email, LinkedIn and GitHub links
- **WebSite** schema (all pages): site title, URL, language, publisher
- **Event** schema (homepage only): loops over `data/luma-events.json` to generate one Event block per upcoming Luma event with name, date, location, image, and organizer

Data is sourced dynamically from `data/cto-de-lyon.json` (organization info) and `data/luma-events.json` (events fetched at build time).

Closes #13

## Test plan

- [x] `npm run build` passes without errors
- [x] 5 valid JSON-LD `<script type="application/ld+json">` blocks present in `public/index.html` (1 Organization + 1 WebSite + 3 Events)
- [x] 2 JSON-LD blocks on non-homepage pages (Organization + WebSite only, no Events)
- [x] All JSON-LD blocks parse as valid JSON (verified with Python `json.loads`)
- [ ] Validate via https://validator.schema.org/ after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)